### PR TITLE
Bugfix/resttemplate logger empty body

### DIFF
--- a/shared-spring/src/main/java/tds/shared/spring/interceptors/RestTemplateLoggingInterceptor.java
+++ b/shared-spring/src/main/java/tds/shared/spring/interceptors/RestTemplateLoggingInterceptor.java
@@ -29,7 +29,9 @@ public class RestTemplateLoggingInterceptor implements ClientHttpRequestIntercep
     }
 
     @Override
-    public ClientHttpResponse intercept(final HttpRequest request, final byte[] body, final ClientHttpRequestExecution clientHttpRequestExecution) throws IOException {
+    public ClientHttpResponse intercept(final HttpRequest request,
+                                        final byte[] body,
+                                        final ClientHttpRequestExecution clientHttpRequestExecution) throws IOException {
         final UUID traceId = UUID.randomUUID();
         logRequest(request, body, traceId);
         ClientHttpResponse response = clientHttpRequestExecution.execute(request, body);
@@ -46,7 +48,7 @@ public class RestTemplateLoggingInterceptor implements ClientHttpRequestIntercep
                 final Object json = objectMapper.readValue(bodyString, Object.class);
                 bodyString = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(json);
             } catch (IOException e) {
-                log.debug("Unable to parse the request as JSON. Printing raw request body string...");
+                log.debug("Unable to parse the request as JSON. Printing raw request body string...", e);
             }
         }
 
@@ -56,14 +58,19 @@ public class RestTemplateLoggingInterceptor implements ClientHttpRequestIntercep
                 " Headers     :   {} \n" +
                 " Body        :   {} \n" +
                 "==============================================================================================",
-            traceId, request.getMethod(), request.getURI(), request.getHeaders(), bodyString);
+            traceId,
+            request.getMethod(), request.getURI(),
+            request.getHeaders(),
+            bodyString.isEmpty() ? "<no body>" : bodyString);
     }
 
     private void logResponse(final ClientHttpResponse response, final UUID traceId) throws IOException {
-        String bodyString;
+        String bodyString = "";
 
         try (final InputStream in = response.getBody()) {
             bodyString = CharStreams.toString(new InputStreamReader(in, Charsets.UTF_8));
+        } catch (IOException e) {
+            log.debug("Unable to open response body", e);
         }
 
         final MediaType contentType = response.getHeaders().getContentType();
@@ -73,7 +80,7 @@ public class RestTemplateLoggingInterceptor implements ClientHttpRequestIntercep
                 final Object json = objectMapper.readValue(bodyString, Object.class);
                 bodyString = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(json);
             } catch (IOException e) {
-                log.debug("Unable to parse the response as JSON. Printing raw response body string...");
+                log.debug("Unable to parse the response as JSON. Printing raw response body string...", e);
             }
         }
 
@@ -84,6 +91,10 @@ public class RestTemplateLoggingInterceptor implements ClientHttpRequestIntercep
         " Headers     :   {} \n" +
         " Body        :   {} \n" +
         "==============================================================================================",
-            traceId, response.getStatusCode(), response.getStatusText(), response.getHeaders(), bodyString);
+            traceId,
+            response.getStatusCode(),
+            response.getStatusText(),
+            response.getHeaders(),
+            bodyString.isEmpty() ? "<no body>" : bodyString);
     }
 }

--- a/shared-spring/src/main/java/tds/shared/spring/interceptors/RestTemplateLoggingInterceptor.java
+++ b/shared-spring/src/main/java/tds/shared/spring/interceptors/RestTemplateLoggingInterceptor.java
@@ -70,6 +70,7 @@ public class RestTemplateLoggingInterceptor implements ClientHttpRequestIntercep
         try (final InputStream in = response.getBody()) {
             bodyString = CharStreams.toString(new InputStreamReader(in, Charsets.UTF_8));
         } catch (IOException e) {
+            // An IOException will be thrown when the body is zero-length (e.g. a 404 response)
             log.debug("Unable to open response body", e);
         }
 

--- a/shared-spring/src/main/java/tds/shared/spring/interceptors/RestTemplateLoggingInterceptor.java
+++ b/shared-spring/src/main/java/tds/shared/spring/interceptors/RestTemplateLoggingInterceptor.java
@@ -80,7 +80,7 @@ public class RestTemplateLoggingInterceptor implements ClientHttpRequestIntercep
                 final Object json = objectMapper.readValue(bodyString, Object.class);
                 bodyString = objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(json);
             } catch (IOException e) {
-                log.debug("Unable to parse the response as JSON. Printing raw response body string...", e);
+                log.debug("Unable to parse the response as JSON.", e);
             }
         }
 


### PR DESCRIPTION
[TDS-817](https://jira.fairwaytech.com/browse/TDS-817):  Add `catch (IOException e)` to handle logging reqeusts/responses with zero-length bodies.

### Notes
* This [pull request](https://github.com/SmarterApp/TDS_Common/pull/38) in `TDS_Common` makes the same update for the RestTemplateLoggingInterceptor for the legacy applications (student/proctor)
* After these PRs are approved, the software that depends on these libraries will be updated to the appropriate release version number (student, proctor, microservices).