### PR TITLE
TDS-1010: IllegalArgumentException: Malformed id: [some UUID]

### DIFF
--- a/shared-spring/src/main/java/tds/shared/spring/interceptors/RestTemplateLoggingInterceptor.java
+++ b/shared-spring/src/main/java/tds/shared/spring/interceptors/RestTemplateLoggingInterceptor.java
@@ -37,7 +37,7 @@ public class RestTemplateLoggingInterceptor implements ClientHttpRequestIntercep
                                         final ClientHttpRequestExecution clientHttpRequestExecution) throws IOException {
 
         // get tracer id that used to associate all rest calls that are a child of this request
-        final String traceId = Optional.fromNullable(MDC.get(TRACER_ID_HEADER)).or(UUID.randomUUID().toString());
+        final String traceId = Optional.fromNullable(MDC.get(TRACER_ID_HEADER)).or(UUID.randomUUID().toString().replace("-", ""));
         logRequest(request, body, traceId);
         final ClientHttpResponse response;
         try {


### PR DESCRIPTION
This execption doesn't seem to have any direct effect on any of the TDS applications; can continue on and complete the exam.